### PR TITLE
Allow 'latest' as version

### DIFF
--- a/src/router/breadcrumbs.js
+++ b/src/router/breadcrumbs.js
@@ -1,3 +1,5 @@
+import { getSphinxVersions, getDoxygenVersions } from "../js/versions"
+
 const skipPaths = [
   // KRM views to skip in the breadcrumbs
 ]
@@ -38,6 +40,9 @@ const hardRoutes = {
 }
 
 function convertToReadableText(bookmarkText) {
+  skipTitles.forEach(title => {
+    bookmarkText = bookmarkText.replaceAll(title, '')
+  })
   bookmarkText = bookmarkText.replaceAll('_', ' ')
   bookmarkText = bookmarkText.replace(/([A-Z])/g, ' $1') // Insert space before capital letter
   bookmarkText = bookmarkText.replace(/([0-9])/g, ' $1') // Insert space before number
@@ -73,16 +78,19 @@ export function calculateBreadcrumbs(to) {
     let lastLink = '/documentation/api'
     let path = to.path.replaceAll(lastLink, '')
     let pages = path.split('/')
+    let version = pages.length > 1 ? pages[1] : null
 
     // Version selector block, clicking v1.2.3 takes you to class list page
-    routes.push({
-      text: pages[1], // Current version
-      name: 'APIReferencePage',
-      disabled: false,
-      hash: '',
-      type: 'versionSelector',
-    })
-    lastLink = lastLink + '/' + pages[1]
+    if (version) {
+      routes.push({
+        text: version === 'latest' ? getDoxygenVersions()[0] : version,
+        name: 'APIReferencePage',
+        disabled: false,
+        hash: '',
+        type: 'versionSelector',
+      })
+      lastLink = lastLink + '/' + pages[1]
+    }
 
     pages = pages.slice(2)
 
@@ -90,16 +98,8 @@ export function calculateBreadcrumbs(to) {
       if (page) {
         lastLink = lastLink + '/' + page
 
-        let bookmarkText = page
-        skipTitles.forEach(title => {
-          bookmarkText = bookmarkText.replaceAll(title, '')
-        })
-        bookmarkText = bookmarkText.replaceAll('_', ' ')
-        bookmarkText = bookmarkText.replace(/([A-Z])/g, ' $1') // Insert space before capital letter
-        bookmarkText = bookmarkText.slice(1) // Removing leading space
-
         routes.push({
-          text: bookmarkText.toUpperCase(),
+          text: convertToReadableText(page).toUpperCase(),
           disabled: false,
           name: 'APIReferencePage',
           hash: '',
@@ -121,9 +121,9 @@ export function calculateBreadcrumbs(to) {
     let version = pages.length > 1 ? pages[1] : null
 
     // Version selector.
-    if(version) {
+    if (version) {
       routes.push({
-        text: version,
+        text: version === 'latest' ? getSphinxVersions()[0] : version,
         name: 'TutorialsPage',
         disabled: false,
         hash: '',
@@ -137,13 +137,13 @@ export function calculateBreadcrumbs(to) {
     let index = 2
     let page = pages[index]
     lastLink += '/' + page
-    while(page && page !== 'index') {
+    while (page && page !== 'index') {
       routes.push({
         text: convertToReadableText(page).toUpperCase(),
         name: 'TutorialsPage',
         disabled: false,
         hash: '',
-        path: lastLink + (index === pages.length-1 ? '' : '/index'),
+        path: lastLink + (index === pages.length - 1 ? '' : '/index'),
         type: 'pageFromPath',
       })
       index += 1

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -99,11 +99,23 @@ const createRouter = () => {
         return { x: 0, y: 0 }
       }
     },
-
   })
 }
 
 const router = createRouter()
+
+router.beforeResolve((to, from, next) => {
+  // Check for occurrences of 'latest' in the version field, and update
+  console.log("before resolve:")
+  console.log(to)
+  if(to.params.version === 'latest' && to.name === 'APIReferencePage') {
+    to.params.version = getDoxygenVersions()[0]
+  }
+  if(to.params.version === 'latest' && to.name === 'TutorialsPage') {
+    to.params.version = getSphinxVersions()[0]
+  }
+  next()
+})
 
 router.beforeEach((to, from, next) => {
   store.commit('setBreadcrumbs', calculateBreadcrumbs(to))


### PR DESCRIPTION
Addresses https://github.com/kerimoyle/website-src/issues/36

Allows the version 'latest' in a URL so that we can have static links elsewhere that redirect easily.  Other versions are shown in the dropdown, and the current version shown is identified there too.

![Screen Shot 2021-01-21 at 3 55 20 PM](https://user-images.githubusercontent.com/46887220/105273982-2e831f80-5c01-11eb-9657-517bb4c6be38.png)
