### PR TITLE
Updated frontpage

### DIFF
--- a/src/components/AboutContent.vue
+++ b/src/components/AboutContent.vue
@@ -8,9 +8,13 @@
         <p>
           The library is intended to be lightweight and focused purely in
           dealing with CellML models. In achieving this, some of the convenience
-          methods/objects that we might expect will not be part of libCellML. If
-          you have feature requests or questions please see **TODO** mailing
-          lists?
+          methods/objects that we might expect will not be part of libCellML.
+          For questions, feature requests, and bug reports about the libCellML library, please visit
+          the <a href="https://github.com/cellml/libcellml/issues" target="_blank">libCellML GitHub repository</a>.
+        </p>
+        <p>
+          For problems with this website, please visit
+          the <a href="https://github.com/libcellml/website-src/issues" target="_blank">website GitHub repository</a>.
         </p>
 
         <h3>Citing libCellML</h3>

--- a/src/components/DocumentationLink.vue
+++ b/src/components/DocumentationLink.vue
@@ -4,17 +4,20 @@
       <v-row>
         <v-col>
           <h3>Documentation versions</h3>
+          <p>
           The links above will take you to the latest versions of the API
           documentation, the Users' Guides, and the Developers' Guides. For
           earlier versions of the documentation, please visit the
           <router-link to="documentation">Documentation page</router-link>.
+          </p>
         </v-col>
       </v-row>
       <v-row>
         <v-col>
+          <p>
           <router-link to="documentation"
             >See the Documentation archives</router-link
-          >
+          ></p>
         </v-col>
       </v-row>
     </div>

--- a/src/components/DownloadLink.vue
+++ b/src/components/DownloadLink.vue
@@ -1,10 +1,10 @@
 <template>
   <v-container>
-    <div>
+    <p>
       <router-link to="download">
         See more information on available versions and requirements
       </router-link>
-    </div>
+    </p>
   </v-container>
 </template>
 

--- a/src/components/DownloadSummary.vue
+++ b/src/components/DownloadSummary.vue
@@ -3,10 +3,25 @@
     <div id="downloadContent">
       <h1>Download libCellML</h1>
       <v-row>
+        <v-col class="col-12">
+          <p>
+            Bianry distributions are not yet ready for release. In the meantime,
+            please follow the instructions on the
+            <a
+              href="/documentation/guides/latest/installation/build_from_source"
+              >Build from source
+            </a>
+            page.
+          </p>
+        </v-col>
+      </v-row>
+
+      <v-row>
         <v-col class="col-12 col-md-3">
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <v-btn block :class="'big-button'" v-on="on">
+              <!-- Added disabled status until this is ready to go -->
+              <v-btn block :class="'big-button'" v-on="on" disabled>
                 <v-icon color="white" x-large>mdi-microsoft-windows</v-icon>
                 <br />
                 Windows
@@ -15,10 +30,12 @@
             <span>Launch installer for Microsoft Windows</span>
           </v-tooltip>
         </v-col>
+
         <v-col class="col-12 col-md-3">
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <v-btn block :class="'big-button'" v-on="on">
+              <!-- Added disabled status until this is ready to go -->
+              <v-btn block :class="'big-button'" v-on="on" disabled>
                 <v-icon color="white" x-large>mdi-linux</v-icon>
                 <br />
                 Linux
@@ -27,10 +44,12 @@
             <span>Launch installer for Linux</span>
           </v-tooltip>
         </v-col>
+
         <v-col class="col-12 col-md-3">
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <v-btn block :class="'big-button'" v-on="on">
+              <!-- Added disabled status until this is ready to go -->
+              <v-btn block :class="'big-button'" v-on="on" disabled>
                 <v-icon color="white" x-large>mdi-apple</v-icon>
                 <br />
                 macOS
@@ -43,7 +62,8 @@
         <v-col class="col-12 col-md-3">
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <v-btn block :class="'big-button'" v-on="on">
+              <!-- Added disabled status until this is ready to go -->
+              <v-btn block :class="'big-button'" v-on="on" disabled>
                 <IconWA />
                 <br />
                 Web assembly


### PR DESCRIPTION
- Added github repo links for comments/bugs into the About section
- Added links to instructions to build from scratch until the downloads are ready
- Moved links into `p` blocks so they're highlighted in red.