### PR TITLE
Review 2 march

### DIFF
--- a/src/components/BreadCrumbs.vue
+++ b/src/components/BreadCrumbs.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="breadcrumbs" id="breadcrumbs">
     <v-container>
-      <template v-if="versionIsOld()">
+      <template v-if="currentVersion !== latest">
         <div class="old-version">
           <router-link :to="{ path: `${latestFullPath}` }">
             You are viewing an old version. Click to see the latest one
@@ -98,11 +98,7 @@ export default {
     items: [],
     version: '',
   }),
-  methods: {
-    versionIsOld() {
-      return false
-    },
-  },
+
   computed: {
     breadcrumbs() {
       return this.$store.state.breadcrumbs
@@ -132,5 +128,16 @@ export default {
   padding: 0.3rem 1rem 0.3rem 0.6rem;
   border-radius: 0.2em;
   font-weight: 500;
+}
+.old-version * {
+  text-decoration: none;
+}
+.old-version a:hover {
+  text-decoration-line: var(--link-decoration-line);
+  text-decoration-style: var(--link-decoration-style);
+  text-decoration-color: var(--link-underline-colour);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 3px;
+  text-decoration-color: var(--bright-red);
 }
 </style>

--- a/src/components/BrokenLink.vue
+++ b/src/components/BrokenLink.vue
@@ -17,10 +17,13 @@
 <script>
 export default {
   name: 'BrokenLink',
-
   computed: {
     lastURL() {
-      return this.$store.getters.getLastURL
+      let lastViaRouter = this.$store.getters.getLastURL
+      if(lastViaRouter) {
+        return lastViaRouter
+      }
+      return window.location.href
     },
   },
 }

--- a/src/components/VersionDropdown.vue
+++ b/src/components/VersionDropdown.vue
@@ -6,18 +6,19 @@
       </v-col>
     </v-row>
     <v-row class="hide-options">
-      <router-link
-        v-for="(version, index) in versionChoices"
-        :key="'version_index_' + index"
-        :id="'version_' + version"
-        :to="{ path: `/documentation/${versionType}/${version}${pagePath}` }"
-      >
-        {{ version }}
+      <template v-for="(version, index) in versionChoices">
+        <router-link
+          :key="'version_index_' + index"
+          :id="'version_' + version"
+          :to="{ path: `/documentation/${versionType}/${version}${pagePath}` }"
+        >
+          {{ version }}
+        </router-link>
         <template v-if="version === currentVersion">
-          <v-icon size="1em">mdi-check</v-icon>
+          <v-icon :key="'version_tick'+version" size="1em">mdi-check</v-icon>
         </template>
-        <br />
-      </router-link>
+        <br :key="'_'+index" />
+      </template>
     </v-row>
   </v-container>
 </template>
@@ -58,7 +59,7 @@ export default {
   methods: {
     expandDropdown() {
       let menu = document.getElementById('dropdown-id')
-      document.addEventListener('click', function(event) {
+      document.addEventListener('click', function (event) {
         var isClickInside = menu.contains(event.target)
         if (!isClickInside) {
           menu.nextSibling.classList = ['hide-options']
@@ -97,6 +98,19 @@ export default {
   border-top: none;
   border-bottom-left-radius: 0.3em;
   border-bottom-right-radius: 0.3em;
+}
+
+.show-options a {
+  text-decoration: none;
+}
+
+.show-options a:hover {
+  text-decoration-line: var(--link-decoration-line);
+  text-decoration-style: var(--link-decoration-style);
+  text-decoration-color: var(--link-underline-colour);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 3px;
+  text-decoration-color: var(--bright-red) !important;
 }
 
 .old-version {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,10 @@ Vue.use(VueRouter)
 
 const DEFAULT_TITLE = 'libCellML'
 
+const guideVersions = getUserGuidesVersions()
+const devVersions = getDevelopersVersions()
+const apiVersions = getApiVersions()
+
 const routes = [
   {
     path: '/',
@@ -53,6 +57,14 @@ const routes = [
     meta: { title: 'libCellML: API' },
     component: () =>
       import(/* webpackChunkName: "api" */ '../views/HelpAPIPage.vue'),
+    beforeEnter: (to, from, next) => {
+      if (apiVersions.includes(to.params.version)) {
+        next()
+      }
+      else {
+        next('/documentation/api/' + apiVersions[0] + '/' + to.params.pageName)
+      }
+    }
   },
   {
     path: '/documentation/api',
@@ -69,6 +81,15 @@ const routes = [
       import(
         /* webpackChunkName: "userguides" */ '../views/GuidesHome.vue'
       ),
+    beforeEnter: (to, from, next) => {
+      // Check that version exists otherwise redirect to latest version
+      if (guideVersions.includes(to.params.version)) {
+        next()
+      }
+      else {
+        next('/documentation/guides/' + guideVersions[0])
+      }
+    },
   },
   {
     path: '/documentation/guides/:version/:pageName*',
@@ -78,12 +99,20 @@ const routes = [
       import(
         /* webpackChunkName: "userguides" */ '../views/HelpTutorialsPage.vue'
       ),
+    beforeEnter: (to, from, next) => {
+      if (guideVersions.includes(to.params.version)) {
+        next()
+      }
+      else {
+        next('/documentation/guides/' + guideVersions[0] + '/' + to.params.pageName)
+      }
+    }
   },
   {
     path: '/documentation/guides',
     redirect: to => {
       // Defaults to latest version, if not specified.
-      return '/documentation/guides/' + getUserGuidesVersions()[0]
+      return '/documentation/guides/' + guideVersions[0]
     },
   },
   {
@@ -92,12 +121,20 @@ const routes = [
     meta: { title: 'libCellML: Developer Guides' },
     component: () =>
       import(/* webpackChunkName: "developers" */ '../views/Developers.vue'),
+    beforeEnter: (to, from, next) => {
+      if (devVersions.includes(to.params.version)) {
+        next()
+      }
+      else {
+        next('/documentation/developers/' + devVersions[0] + '/' + to.params.pageName)
+      }
+    }
   },
   {
     path: '/documentation/developers',
     redirect: to => {
       // Defaults to latest version, if not specified.
-      return '/documentation/developers/' + getDevelopersVersions()[0]
+      return '/documentation/developers/' + devVersions[0]
     },
   },
   {
@@ -113,6 +150,10 @@ const routes = [
     meta: { title: 'libCellML: Not Found' },
     component: () =>
       import(/* webpackChunkName: "notFound" */ '../views/NotFound.vue'),
+    beforeEnter: (to, from, next) => {
+      store.commit('updateLastURL', to.path)
+      next()
+    }
   },
   {
     path: '/network-issue',
@@ -123,11 +164,16 @@ const routes = [
       ),
   },
   {
-    path: '*',
-    redirect: {
-      name: '404',
-      params: { resource: 'page' },
-    },
+    path: '/:pathMatch(.*)*',
+    name: 'NotFound',
+    component: () =>
+      import(
+      /* webpackChunkName: "notFound" */ '../views/NotFound.vue'
+      ),
+    beforeEnter: (to, from, next) => {
+      store.commit('updateLastURL', to.path)
+      next()
+    }
   },
 ]
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -150,10 +150,6 @@ const routes = [
     meta: { title: 'libCellML: Not Found' },
     component: () =>
       import(/* webpackChunkName: "notFound" */ '../views/NotFound.vue'),
-    beforeEnter: (to, from, next) => {
-      store.commit('updateLastURL', to.path)
-      next()
-    }
   },
   {
     path: '/network-issue',


### PR DESCRIPTION
- 404 page lists pages: currently treats errors via the router differently to errors via the URL.  The first goes to a 404 page, the second simply shows the 404 page content without changing the URL.

- breadcrumbs to include warning of versions

- invalid versions default to latest version