### PR TITLE
Describe how service "imports" CellML 1.x models

### DIFF
--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -3,7 +3,7 @@
     <h1>Import CellML models</h1>
     <p>
       This service will accept CellML 1.0 or CellML 1.1 files and import them
-      into CellML 2.0.
+      into CellML 2.0 by parsing them using libCellML in non-strict mode.
     </p>
     <v-container>
       <v-file-input


### PR DESCRIPTION
I think it might be useful to provide a bit more detail on how libCellML is used to "import" CellML 1.x models into CellML 2.0 models. Not sure this is the best way to do so, however.